### PR TITLE
add issue template for planning

### DIFF
--- a/.github/ISSUE_TEMPLATE/meetup-planning.md
+++ b/.github/ISSUE_TEMPLATE/meetup-planning.md
@@ -1,0 +1,109 @@
+---
+name: 📅 Meetup Planning
+about: Plan and track a DevOps Kathmandu meetup
+title: "Meetup: [Number] – [Title or Theme]"
+labels: ["meetup", "planning"]
+assignees: ''
+---
+
+## 🗓️ Meetup Details
+
+**Meetup Number:**  
+(e.g., 36)
+
+**Proposed Date & Time:**  
+(e.g., May 26, 2025 – 5:00 PM to 7:00 PM NPT)
+
+**Confirmed Date & Time:**  
+(Update once finalized)
+
+**Meetup Link:**  
+(e.g., https://www.meetup.com/DevOps-Kathmandu/events/)
+
+---
+
+## 🎤 Speakers
+
+- **Name:**  
+  **Title/Role:**  
+  **Topic:**  
+  **GitHub:**  
+  **LinkedIn:**  
+
+*(Add more speakers if needed)*
+
+---
+
+## 📝 Description
+
+**Title/Theme:**  
+(e.g., “CI/CD for Beginners”)
+
+**Short Summary:**  
+(A few lines explaining what this meetup will cover)
+
+---
+
+## 📍 Venue
+
+**Location:**  
+(e.g., Adex International, Ekantakuna)
+
+**Capacity:**  
+(e.g., 40 attendees)
+
+**Venue Sponsor:**  
+(e.g., Adex International)
+
+**Refreshments Sponsor:**  
+(e.g., ShowSeeker)
+
+---
+
+## ✅ Checklist
+
+- [ ] Confirm speakers
+- [ ] Finalize venue
+- [ ] Create Meetup event
+- [ ] Publish on social media
+- [ ] Design event banner
+- [ ] Arrange refreshments
+- [ ] Confirm volunteers
+- [ ] Prepare slides/recording setup
+- [ ] Post-event feedback collection
+
+---
+
+## 🙋 Volunteers
+
+- **Event Lead:**  
+- **Promotion:**  
+- **Logistics:**  
+- **Photography/Videography:**  
+- **Feedback & Reporting:**  
+
+---
+
+## 📸 Media
+
+- **Banner Image:**  
+- **Social Links:**  
+  - [ ] LinkedIn  
+  - [ ] Facebook  
+  - [ ] Twitter  
+- **Hashtags:**  
+  (e.g., #DevOpsKathmandu, #DevOpsMeetup)
+
+---
+
+## 📚 Resources
+
+- **Reference Issue:**  
+  (Link to previous meetup planning issue)
+
+- **Slides (if any):**  
+- **Recording (if any):**
+
+---
+
+Please update this issue regularly as things progress! 🛠️

--- a/docs/ATTENDEE_GUIDE.md
+++ b/docs/ATTENDEE_GUIDE.md
@@ -1,0 +1,63 @@
+# 🙋 DevOps Kathmandu – Attendee Guide
+
+Welcome to DevOps Kathmandu! Whether you’re a first-timer or a regular, we’re excited to have you join the meetup. Here’s what to expect and how to make the most of your time with us.
+
+---
+
+## 🗓️ Before the Event
+
+### ✅ RSVP on Meetup
+Make sure you're registered on our [Meetup page](https://www.meetup.com/devops-kathmandu/) so we can plan seating, snacks, and (most importantly) **pizza 🍕**.
+
+### 🎒 What to Bring
+- Curiosity and questions!
+- A notebook or laptop (optional)
+- Water bottle (we usually provide drinks too)
+
+---
+
+## 📍 At the Event
+
+### 🕔 Timing
+- Most meetups happen on **Friday evenings, 5:00–7:00 PM**
+- Try to arrive before 5:30 PM to avoid missing the intro
+
+### 🎙️ What Happens
+- Welcome & intro
+- 1–2 technical sessions
+- Q&A, discussion, and networking
+- **Snacks and pizza!**
+
+### 🙌 Code of Conduct
+We strive for a welcoming, respectful, and harassment-free space. Please read and follow our [Code of Conduct](https://connect.devopskathmandu.com/code-of-conduct/).
+
+---
+
+## 💬 During the Event
+
+### Get Involved
+- Ask questions, no matter your experience level
+- Connect with speakers and fellow attendees
+- Take photos and tag us:  
+  - [LinkedIn](https://www.linkedin.com/company/devops-kathmandu)  
+  - [Twitter/X](https://twitter.com/DevOpsKathmandu)
+
+---
+
+## 📸 After the Event
+
+### Stay Connected
+- Join our [Discord Community](https://discord.devopskathmandu.com)
+- Check out slides, recordings, and recaps (we’ll post links on Meetup)
+- Watch for the next event — or volunteer with us!
+
+---
+
+## 📞 Contact Us
+
+Got questions or feedback? We’d love to hear from you!
+
+- 📧 devopskathmandu@gmail.com
+- 📍 [Meetup Page](https://www.meetup.com/devops-kathmandu/)
+
+Let’s learn, share, and build the DevOps community together!

--- a/docs/SPEAKER_GUIDE.md
+++ b/docs/SPEAKER_GUIDE.md
@@ -1,0 +1,62 @@
+# 🎤 DevOps Kathmandu – Speaker Guidelines
+
+Thank you for being part of DevOps Kathmandu! We're excited to have you share your knowledge with the community. Here’s everything you need to know to make your session smooth, engaging, and impactful.
+
+---
+
+## 🧭 Before the Meetup
+
+### ✅ What We Need From You
+
+- **Session Title**: Keep it catchy but clear
+- **Short Description**: 2–4 sentences about your topic
+- **Your Bio**: 2–3 lines + social links (GitHub, LinkedIn, etc.)
+- **Headshot (Optional)**: For our promo banner
+- **Slides (Optional)**: If you’ll be using any
+
+> Please share these details at least **5 days before the event**, so we can promote effectively.
+
+---
+
+## 📅 On the Day
+
+### 📍 Arrival & Setup
+- Please arrive **20–30 minutes early** and stay till the end of event
+- We’ll provide a projector, mic, and clicker (if needed)
+- Bring your own laptop or let us know in advance if you need one
+
+### 🎙️ Presentation Style
+- Keep it **community-focused and inclusive**
+- Slides are optional — storytelling is always welcome!
+- If you want to do a live demo, test setup during prep time
+
+### 🕐 Time Allocation
+- **Talks**: 20–30 minutes
+- **Q&A**: 5–10 minutes after your talk
+- Let us know if you need more/less time — we’re flexible!
+
+---
+
+## 🙅 What to Avoid
+
+- No sales pitches or aggressive product promotion
+- Avoid offensive, exclusionary, or sensitive content
+- Respect attendee diversity — we follow a [Code of Conduct](https://connect.devopskathmandu.com/code-of-conduct/)
+
+---
+
+## ❤️ After the Meetup
+
+- We’d love to feature your session recap on social media
+- If you're open to sharing slides or recordings, we’ll link them with your permission
+- Want to speak again or refer a friend? Let’s talk!
+
+---
+
+## 📨 Questions?
+
+Reach out anytime:
+- 📧 devopskathmandu@gmail.com
+- 💬 [Meetup Page](https://www.meetup.com/devops-kathmandu/)
+
+Thanks again for being a part of DevOps Kathmandu — we can't wait for your session!

--- a/docs/VENUE_SPONSOR_GUIDE.md
+++ b/docs/VENUE_SPONSOR_GUIDE.md
@@ -1,0 +1,67 @@
+# 🏢 DevOps Kathmandu - Regular Meetups | Venue Sponsor Guidelines
+
+Thank you for considering hosting a DevOps Kathmandu meetup at your venue! Your support helps foster Nepal’s DevOps community. This document outlines expectations and benefits for venue sponsors.
+
+---
+
+## 📍 Venue Requirements
+
+- **Capacity**: 60–100 attendees.
+- **Accessibility**: Easily reachable and inclusive for all.
+- **Facilities**:
+  - Projector or large display
+  - Microphone & sound system
+  - Stable Wi-Fi
+  - Seating for attendees
+  - Clean restrooms
+- **Safety**: Compliance with local regulations and clear emergency exits.
+
+---
+
+## 🍕 Refreshment Expectations
+
+Providing **light snacks, coffee, and pizza** has become a cherished tradition at our meetups.
+
+We ask venue sponsors to arrange:
+- Tea/coffee & drinking water
+- Light snacks (e.g., cookies, fruits, or sandwiches)
+- Pizza (yes, it’s kind of a ritual now 🙂)
+
+If full support isn't feasible, we're happy to co-arrange this.
+
+---
+
+## 🎁 Sponsor Benefits
+
+- **Brand Visibility**: Logo on banners, slides, and event promos.
+- **Shoutouts**: Featured in our Meetup, LinkedIn, and Twitter/X posts.
+- **Community Cred**: Recognition as a local tech enabler.
+- **Networking**: Connect with DevOps professionals, speakers, and potential hires.
+
+---
+
+## 🤝 Sponsor Commitments
+
+- Venue available free of charge (including setup time)
+- Help from an on-site point of contact
+- Co-promote the event through your channels
+- Maintain a welcoming and respectful environment (see our [Code of Conduct](https://connect.devopskathmandu.com/code-of-conduct/))
+
+---
+
+## 📅 Event Logistics
+
+- **Time**: Usually Friday evenings (5–7 PM)
+- **Setup**: Organizers arrive 30–60 mins early
+- **Cleanup**: We’ll leave the venue as we found it
+
+---
+
+## 📞 Contact
+
+Want to sponsor or have questions?
+
+- 📧 devopskathmandu@gmail.com  
+- 🔗 [Meetup Page](https://www.meetup.com/devops-kathmandu/)
+
+Thanks for supporting the DevOps community (and keeping the pizza spirit alive)!


### PR DESCRIPTION
### 📌 Summary

Adds a reusable GitHub issue template for planning DevOps Kathmandu meetups.

### ✅ What's Included

- `.github/ISSUE_TEMPLATE/meetup-planning.md`
- `docs/`
- Sections for date, speakers, venue, sponsors, checklist, volunteers, and media

### 🎯 Purpose

To streamline meetup planning with a consistent and collaborative format.